### PR TITLE
Authorization middleware

### DIFF
--- a/Sources/App/Algebras/Authorization.swift
+++ b/Sources/App/Algebras/Authorization.swift
@@ -1,5 +1,5 @@
 import BowEffects
 
 protocol Authorization {
-    func verify(_ bearer: String) -> EnvIO<BearerEnvironment, BearerError, BearerPayload>
+    func verify(_ bearer: String) -> EnvIO<BearerEnvironment, BearerError, Bearer>
 }

--- a/Sources/App/Instances/AuthorizationServer.swift
+++ b/Sources/App/Instances/AuthorizationServer.swift
@@ -5,14 +5,14 @@ import BowEffects
 
 final class AuthorizationServer: Authorization {
     
-    func verify(_ bearer: String) -> EnvIO<BearerEnvironment, BearerError, BearerPayload> {
+    func verify(_ bearer: String) -> EnvIO<BearerEnvironment, BearerError, Bearer> {
         let bearerPayload = EnvIO<BearerEnvironment, BearerError, BearerPayload>.var()
         let verifiedPayload = EnvIO<BearerEnvironment, BearerError, BearerPayload>.var()
         
         return binding(
              bearerPayload <- self.getPayload(bearer: bearer),
            verifiedPayload <- self.verify(payload: bearerPayload.get),
-        yield: verifiedPayload.get)^
+        yield: .init(payload: verifiedPayload.get))^
     }
     
     // MARK: - Bearer

--- a/Sources/App/Middlewares/Bearer+Authenticatable.swift
+++ b/Sources/App/Middlewares/Bearer+Authenticatable.swift
@@ -1,0 +1,3 @@
+import Vapor
+
+extension Bearer: Authenticatable {}

--- a/Sources/App/Middlewares/BearerAuthorizationMiddleware.swift
+++ b/Sources/App/Middlewares/BearerAuthorizationMiddleware.swift
@@ -1,0 +1,18 @@
+import Vapor
+import Bow
+import BowEffects
+
+struct BearerAuthorizationMiddleware: BearerAuthenticator {
+    let authorization: Authorization
+    let environment: BearerEnvironment
+    
+    func authenticate(bearer: BearerAuthorization, for request: Request) -> EventLoopFuture<Void> {
+        let queue: DispatchQueue = .init(label: String(describing: PlaygroundBookController.self), qos: .userInitiated)
+        
+        return authorization.verify(bearer.token)
+            .provide(environment)
+            .map { bearer in request.auth.login(bearer) }^
+            .unsafeRunSyncEither(on: queue)
+            .eventLoopFuture(for: request)
+    }
+}

--- a/Sources/App/Middlewares/Either+EventLoopFuture.swift
+++ b/Sources/App/Middlewares/Either+EventLoopFuture.swift
@@ -1,0 +1,16 @@
+import Vapor
+import Bow
+
+extension Either where A: Error {
+    
+    func eventLoopFuture(for request: Request) -> EventLoopFuture<Void> {
+        self.fold(
+            { a in
+                request.eventLoop.future(error: a)
+            },
+            { b in
+                request.eventLoop.future()
+            }
+        )
+    }
+}

--- a/Sources/App/routes.swift
+++ b/Sources/App/routes.swift
@@ -6,7 +6,11 @@ struct RouteRegister {
     
     func playgroundBook() throws {
         let controller = PlaygroundBookController(playgroundBook: PlaygroundBookServer(), config: config)
-        app.webSocket("playgroundBook", onUpgrade: controller.handler)
+        let bearerAuth = try BearerAuthorizationMiddleware(authorization: AuthorizationServer(), environment: bearerEnvironment())
+        
+        app.grouped(bearerAuth)
+           .grouped(Bearer.guardMiddleware())
+           .webSocket("playgroundBook", onUpgrade: controller.handler)
     }
     
     func appleSignIn() throws {
@@ -18,7 +22,7 @@ struct RouteRegister {
         app.post("signin", use: controller.handle)
     }
     
-    // MARK: - Environment
+    // MARK: - Environments
     private func signInEnvironment() throws -> SignInEnvironment {
         try .init(signIn: appleEnvironment(), bearer: bearerEnvironment())
     }


### PR DESCRIPTION
## Details
Given a `Bearer` as a response from Sign-In service, the client must use it for authenticating the services. This PR adds a bearer authorization as a guard for opening the WebSocket.