### PR TITLE
Encode responses

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,6 @@
 ## Build files
 Dockerfile
+app.yaml
 Packages/
 Package.pins
 Package.resolved

--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,6 @@ Package.resolved
 ## Vapor
 .env.*
 .run
+
+## Google Cloud
+app.yaml

--- a/Sources/App/Controllers/AppleSignInController.swift
+++ b/Sources/App/Controllers/AppleSignInController.swift
@@ -14,7 +14,7 @@ final class AppleSignInController {
     
     func handle(request: Request) throws -> String {
         let queue: DispatchQueue = .init(label: String(describing: AppleSignInController.self), qos: .userInitiated)
-
+        
         return try run(request: request)
             .provide(config)
             .unsafeRunSync(on: queue)
@@ -55,4 +55,10 @@ final class AppleSignInController {
                 }^
         }^
     }
+}
+
+
+extension SignInError: AbortError {
+    var status: HTTPResponseStatus { .internalServerError }
+    var reason: String { "\(self)" }
 }

--- a/Sources/App/Controllers/Errors/SignInError.swift
+++ b/Sources/App/Controllers/Errors/SignInError.swift
@@ -6,3 +6,14 @@ enum SignInError: Error {
     case appleToken(AppleTokenError)
     case bearer(BearerError)
 }
+
+extension SignInError: CustomStringConvertible {
+    var description: String {
+        switch self {
+        case .invalidCodification(let error): return "\(error)"
+        case .jwt(let error): return "JWT: \(error)"
+        case .appleToken(let error): return "Apple Token: \(error)"
+        case .bearer(let error): return "Bearer: \(error)"
+        }
+    }
+}

--- a/Sources/App/Controllers/Errors/WebSocketError.swift
+++ b/Sources/App/Controllers/Errors/WebSocketError.swift
@@ -2,6 +2,7 @@ import Foundation
 
 enum WebSocketError: Error {
     case encoding(error: Error)
+    case utf8Expected
     case decoding(error: Error)
     case decoding(text: String)
     case sending(error: Error)

--- a/Sources/App/Controllers/PlaygroundBookController.swift
+++ b/Sources/App/Controllers/PlaygroundBookController.swift
@@ -20,3 +20,8 @@ final class PlaygroundBookController {
         }
     }
 }
+
+extension PlaygroundBookConfig: AbortError {
+    var status: HTTPResponseStatus { .internalServerError }
+    var reason: String { "\(self)" }
+}

--- a/Sources/App/Controllers/Utils/WebSocket+Extensions.swift
+++ b/Sources/App/Controllers/Utils/WebSocket+Extensions.swift
@@ -7,21 +7,12 @@ import BowEffects
 extension WebSocket: WebSocketOutput {
     
     func send<D>(binary: Data) -> EnvIO<D, WebSocketError, Void> {
-        EnvIO.async { callback in
+        EnvIO.invoke { _ in
             guard let message = String(data: binary, encoding: .utf8) else {
-                callback(.left(WebSocketError.sending(data: binary)))
-                return
+                throw WebSocketError.utf8Expected
             }
             
-            let promise = self.eventLoop.makePromise(of: Void.self)
-            promise.futureResult.whenFailure { error in
-                callback(.left(WebSocketError.sending(error: error)))
-            }
-            promise.futureResult.whenSuccess {
-                callback(.right(()))
-            }
-            
-            self.send(message, promise: promise)
+            self.send(message)
         }^
     }
 }


### PR DESCRIPTION
This PR encode the response in case action finishes with some error. Currently, we are showing default error 500 messages.
- Fix bug in WebSocket - sync between NIO and Bow.