### PR TITLE
Fix bug in SPM about "tscbasic.grapherror.unexpectedcycle”

### DIFF
--- a/Sources/App/Controllers/Models/SwiftPackage.swift
+++ b/Sources/App/Controllers/Models/SwiftPackage.swift
@@ -8,13 +8,14 @@ struct SwiftPackage: Codable {
 
 extension PlaygroundRecipe {
     var swiftPackage: SwiftPackage {
+        let packageName = "\(name)-\(UUID())"
         let listOfDependencies = dependencies.map { "\t\t\($0.swiftPackage)" }.joined(separator: ",\n")
         let content =   """
                         // swift-tools-version:5.1
                         import PackageDescription
 
                         let package = Package(
-                            name: "\(name)",
+                            name: "\(packageName)",
                             dependencies: [
                         \(listOfDependencies)
                             ]


### PR DESCRIPTION
## Details
This PR fixes a bug when the Package has the same name as some of its dependencies. SPM could not resolve the dependency graph: dependency cycles.